### PR TITLE
Fixed desync with client and viewer not initializing

### DIFF
--- a/server.py
+++ b/server.py
@@ -108,6 +108,9 @@ class GameServer:
                         logger.info("Viewer connected")
                         self.viewers.add(websocket)
 
+                game_info = self.game.info()
+                await websocket.send(json.dumps(game_info))
+
                 if (
                     data["cmd"] == "key"
                     and self.current_player
@@ -123,6 +126,8 @@ class GameServer:
             logger.info("Client disconnected: %s", closed_reason)
             if websocket in self.viewers:
                 self.viewers.remove(websocket)
+            if self.current_player and self.current_player.ws == websocket:
+                self.current_player = await self.players.get()
 
     async def mainloop(self):
         """Run the game."""


### PR DESCRIPTION
The viewer did not initialize after pulling the latest changes, after further inspection I was able to fix that and the desync created when the client was restarted too quickly by creating a new game everytime a socket closes.